### PR TITLE
Fix RTD build: remove unused apt packages and ignore build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,7 @@
 _build/*
 locales/**/*.mo
 locales/pot/*
+locales/*.gif
+locales/*.h5
+locales/*.xdmf
 tx

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,8 +5,6 @@ build:
   tools:
     python: "3.12"
   apt_packages:
-    - libgl1-mesa-dev
-    - xvfb
     - pandoc
   jobs:
     post_create_environment:


### PR DESCRIPTION
## Summary

- Remove `libgl1-mesa-dev` and `xvfb` from `build.apt_packages` in `.readthedocs.yaml`, aligning with the upstream felupe repo ([adtzlr/felupe@e72247cf](https://github.com/adtzlr/felupe/commit/e72247cf)). These packages have been unnecessary since PyVista 0.45.0+ deprecated `start_xvfb()` for headless rendering.
- Add `locales/*.gif`, `locales/*.h5`, `locales/*.xdmf` to `.gitignore` to prevent simulation output files (generated by `pyvista-plot` directives in docstrings, e.g. `AnimationWriterPlugin`) from being committed to the repo and then copied into the Sphinx source tree via `post_create_environment`.

## Fixes

Fixes https://app.readthedocs.org/projects/felupe-ja/builds/32531324/

## Test plan

- [ ] Trigger a new RTD build after merging and confirm it passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)