### PR TITLE
ci: remove token from checkout action for public submodules

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: true
-          token: ${{ secrets.PERSONAL_ACCESSTOKEN }}
       - name: Setup SSH
         uses: MrSquaare/ssh-setup-action@v4
         with:


### PR DESCRIPTION
The submodules in this repository are all public, so a Personal Access Token is not required for `actions/checkout`. Removing it resolves the Dependabot workflow error: `Input required and not supplied: token`.