### PR TITLE
ci: remove heavy optional dependencies from requirements to fix RTD segfault

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-felupe[all,docs,examples] @ git+https://github.com/adtzlr/felupe.git
+felupe[docs] @ git+https://github.com/adtzlr/felupe.git
 sphinx-intl[transifex]==2.3.2


### PR DESCRIPTION
The ReadTheDocs build for `felupe-ja` has been consistently failing with a segmentation fault when sphinx-gallery runs `ex16_deeplearning-torch.py`. This is caused by `torch` and `pyvista[jupyter]` (pulled in via `[all,examples]` extras) initializing GPU/OpenGL in a headless CI environment.

Changing to `felupe[docs]` removes these heavy optional dependencies. Since the GitHub Actions workflow already sets `plot_gallery=0`, only the sphinx extensions from `[docs]` are needed for gettext extraction.